### PR TITLE
update grafana agent entrypoint

### DIFF
--- a/local/docker-compose.yaml
+++ b/local/docker-compose.yaml
@@ -93,7 +93,7 @@ services:
       - ./logs/hello-observability.log:/tmp/hello-observability.log
       - ./logs/access_log.log:/tmp/access_log.log
     entrypoint:
-      - /bin/agent
+      - /bin/grafana-agent
       - -config.file=/etc/agent-config/agent.yaml
       - -metrics.wal-directory=/tmp/agent/wal
       - -enable-features=integrations-next


### PR DESCRIPTION
Update grafana agent entrypoint:

Lastest grafana agent doesn't have /bin/agent, it has been upgraded to /bin/grafana-agent.